### PR TITLE
Rework of api:

### DIFF
--- a/cmd/test_pci_walk/main.go
+++ b/cmd/test_pci_walk/main.go
@@ -11,11 +11,12 @@ func main() {
 	h := hwapi.GetAPI()
 	if err := h.PCIEnumerateVisibleDevices(
 		func(d hwapi.PCIDevice) (abort bool) {
-			var venid, devid uint16
-			if err := h.PCIReadConfigSpace(d, 0, &venid); err != nil {
+			venid, err := h.PCIReadConfigSpace(d, 0, 2)
+			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v", err)
 			}
-			if err := h.PCIReadConfigSpace(d, 2, &devid); err != nil {
+			devid, err := h.PCIReadConfigSpace(d, 2, 2)
+			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v", err)
 			}
 

--- a/pkg/hwapi/acpi.go
+++ b/pkg/hwapi/acpi.go
@@ -64,7 +64,7 @@ type acpiXsdt struct {
 	//Entry           []uint64 count depend on Length field
 }
 
-func (h HwAPI) GetACPITableSysFS(n string) ([]byte, error) {
+func GetACPITableSysFS(h LowLevelHardwareInterfaces, n string) ([]byte, error) {
 	buf, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", acpiSysfsPath, n))
 	if err != nil {
 		return nil, fmt.Errorf("cannot access sysfs path %s: %s", acpiSysfsPath, err)
@@ -285,7 +285,7 @@ func scanReservedMem(l LowLevelHardwareInterfaces) ([]byte, ACPIRsdp, error) {
 
 	buf := make([]byte, binary.Size(rsdp))
 
-	_, err := iterateOverE820Ranges("ACPI Tables", func(start uint64, end uint64) bool {
+	_, err := l.IterateOverE820Ranges("ACPI Tables", func(start uint64, end uint64) bool {
 		for i := int64(start); i < int64(end)-int64(binary.Size(rsdp)); i += 16 {
 			err := l.ReadPhysBuf(i, buf)
 			if err != nil {
@@ -405,7 +405,7 @@ func getACPITableDevMemRSDP(l LowLevelHardwareInterfaces) ([]byte, ACPIRsdp, err
 	return nil, rsdp, fmt.Errorf("RSDP not found")
 }
 
-func (h HwAPI) GetACPITableDevMem(n string) ([]byte, error) {
+func GetACPITableDevMem(h LowLevelHardwareInterfaces, n string) ([]byte, error) {
 	rsdpBuf, rsdp, err := getACPITableDevMemRSDP(h)
 	if err != nil {
 		return nil, err
@@ -505,9 +505,9 @@ func (h HwAPI) GetACPITable(n string) ([]byte, error) {
 	}
 
 	// Try SYSFS first, but it doesn't has RSDP
-	tbl, err := h.GetACPITableSysFS(n)
+	tbl, err := GetACPITableSysFS(h, n)
 	if err != nil {
-		tbl, err = h.GetACPITableDevMem(n)
+		tbl, err = GetACPITableDevMem(h, n)
 	}
 	return tbl, err
 }

--- a/pkg/hwapi/api.go
+++ b/pkg/hwapi/api.go
@@ -16,9 +16,7 @@ type LowLevelHardwareInterfaces interface {
 	CPULogCount() uint32
 
 	// e820.go
-	IsReservedInE820(start uint64, end uint64) (bool, error)
-	UsableMemoryAbove4G() (size uint64, err error)
-	UsableMemoryBelow4G() (size uint64, err error)
+	IterateOverE820Ranges(target string, callback func(start uint64, end uint64) bool) (bool, error)
 
 	// iommu.go
 	LookupIOAddress(addr uint64, regs VTdRegisters) ([]uint64, error)

--- a/pkg/hwapi/api.go
+++ b/pkg/hwapi/api.go
@@ -30,10 +30,6 @@ type LowLevelHardwareInterfaces interface {
 	PCIReadConfigSpace(d PCIDevice, off int, len int) ([]byte, error)
 	PCIWriteConfigSpace(d PCIDevice, off int, val interface{}) error
 
-	// hostbridge.go
-	ReadHostBridgeTseg() (uint32, uint32, error)
-	ReadHostBridgeDPR() (DMAProtectedRange, error)
-
 	// phys.go
 	ReadPhys(addr int64, data UintN) error
 	ReadPhysBuf(addr int64, buf []byte) error

--- a/pkg/hwapi/api.go
+++ b/pkg/hwapi/api.go
@@ -20,7 +20,6 @@ type LowLevelHardwareInterfaces interface {
 
 	// iommu.go
 	LookupIOAddress(addr uint64, regs VTdRegisters) ([]uint64, error)
-	AddressRangesIsDMAProtected(first, end uint64) (bool, error)
 
 	// msr.go
 	ReadMSR(msr int64) []uint64

--- a/pkg/hwapi/api.go
+++ b/pkg/hwapi/api.go
@@ -46,8 +46,6 @@ type LowLevelHardwareInterfaces interface {
 
 	// smbios.go
 	IterateOverSMBIOSTables(n uint8, callback func(s *smbios.Structure) bool) (ret bool, err error)
-	IterateOverSMBIOSTablesType0(callback func(t0 *SMBIOSType0) bool) (ret bool, err error)
-	IterateOverSMBIOSTablesType17(callback func(t17 *SMBIOSType17) bool) (ret bool, err error)
 }
 
 //HwAPI The context object for low level hardware api

--- a/pkg/hwapi/api.go
+++ b/pkg/hwapi/api.go
@@ -25,20 +25,11 @@ type LowLevelHardwareInterfaces interface {
 	AddressRangesIsDMAProtected(first, end uint64) (bool, error)
 
 	// msr.go
-	ReadMSR(msr int64, core int) (uint64, error)
-
-	// msr_intel.go
-	HasSMRR() (bool, error)
-	GetSMRRInfo() (SMRR, error)
-	IA32FeatureControlIsLocked() (bool, error)
-	IA32PlatformID() (uint64, error)
-	AllowsVMXInSMX() (bool, error)
-	TXTLeavesAreEnabled() (bool, error)
-	IA32DebugInterfaceEnabledOrLocked() (*IA32Debug, error)
+	ReadMSR(msr int64) []uint64
 
 	// pci.go
 	PCIEnumerateVisibleDevices(cb func(d PCIDevice) (abort bool)) (err error)
-	PCIReadConfigSpace(d PCIDevice, off int, out interface{}) error
+	PCIReadConfigSpace(d PCIDevice, off int, len int) ([]byte, error)
 	PCIWriteConfigSpace(d PCIDevice, off int, val interface{}) error
 
 	// hostbridge.go

--- a/pkg/hwapi/api.go
+++ b/pkg/hwapi/api.go
@@ -43,8 +43,7 @@ type LowLevelHardwareInterfaces interface {
 	ReadPCR(tpmCon *TPM, pcr uint32) ([]byte, error)
 
 	// acpi.go
-	GetACPITableDevMem(n string) ([]byte, error)
-	GetACPITableSysFS(n string) ([]byte, error)
+	GetACPITable(n string) ([]byte, error)
 
 	// smbios.go
 	IterateOverSMBIOSTables(n uint8, callback func(s *smbios.Structure) bool) (ret bool, err error)

--- a/pkg/hwapi/e820_test.go
+++ b/pkg/hwapi/e820_test.go
@@ -20,7 +20,7 @@ func TestE820ReservedCheck(t *testing.T) {
 	}
 
 	for _, s := range ranges {
-		reserved, err := h.IsReservedInE820(s.start, s.end)
+		reserved, err := IsReservedInE820(h, s.start, s.end)
 		if err != nil {
 			t.Errorf("Checking range %x-%x failed: %s", s.start, s.end, err)
 		}

--- a/pkg/hwapi/hostbridge.go
+++ b/pkg/hwapi/hostbridge.go
@@ -105,7 +105,7 @@ var (
 )
 
 //ReadHostBridgeTseg returns TSEG base and TSEG limit
-func (h HwAPI) ReadHostBridgeTseg() (uint32, uint32, error) {
+func ReadHostBridgeTseg(h LowLevelHardwareInterfaces) (uint32, uint32, error) {
 	var tsegBaseOff int
 	var tsegLimitOff int
 	var tsegBroadwellDEfix bool
@@ -184,7 +184,7 @@ type DMAProtectedRange struct {
 }
 
 //ReadHostBridgeDPR reads the DPR register from PCI config space
-func (h HwAPI) ReadHostBridgeDPR() (DMAProtectedRange, error) {
+func ReadHostBridgeDPR(h LowLevelHardwareInterfaces) (DMAProtectedRange, error) {
 	var dprOff int
 	var devicenum int
 	var ret DMAProtectedRange

--- a/pkg/hwapi/iommu.go
+++ b/pkg/hwapi/iommu.go
@@ -299,8 +299,8 @@ func lookupIOScalable(addr, rootTblAddr uint64) ([]uint64, error) {
 }
 
 // AddressRangesIsDMAProtected returns true if the address is DMA protected by the IOMMU
-func (h HwAPI) AddressRangesIsDMAProtected(first, end uint64) (bool, error) {
-	regs, err := readVTdRegs(h)
+func AddressRangesIsDMAProtected(l LowLevelHardwareInterfaces, first, end uint64) (bool, error) {
+	regs, err := readVTdRegs(l)
 	if err != nil {
 		return false, err
 	}
@@ -319,7 +319,7 @@ func (h HwAPI) AddressRangesIsDMAProtected(first, end uint64) (bool, error) {
 	}
 
 	for addr := first & 0xffffffffffff0000; addr < end; addr += 4096 {
-		vas, err := h.LookupIOAddress(addr, regs)
+		vas, err := l.LookupIOAddress(addr, regs)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/hwapi/msr.go
+++ b/pkg/hwapi/msr.go
@@ -1,19 +1,29 @@
 package hwapi
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/fearful-symmetry/gomsr"
 )
 
 // ReadMSR returns the MSR on core #0
-func (h HwAPI) ReadMSR(msr int64, core int) (uint64, error) {
-	msrCtx, err := gomsr.MSR(core)
-	if err != nil {
-		return 0, err
-	}
-	msrData, err := msrCtx.Read(msr)
-	if err != nil {
-		return 0, err
+func (h HwAPI) ReadMSR(msr int64) []uint64 {
+	count := 0
+	var ret []uint64
+	for {
+		msrCtx, err := gomsr.MSR(count)
+		if err != nil {
+			fmt.Fprintf(os.Stdout, "ReadMSR - gomsr.MSR context aborted with: %v\n", err)
+			break
+		}
+		msrData, err := msrCtx.Read(msr)
+		if err != nil {
+			fmt.Fprintf(os.Stdout, "ReadMSR - msrCtx.Read aborted with: %v\n", err)
+			break
+		}
+		ret = append(ret, msrData)
 	}
 
-	return msrData, nil
+	return ret
 }

--- a/pkg/hwapi/msr_intel.go
+++ b/pkg/hwapi/msr_intel.go
@@ -1,9 +1,5 @@
 package hwapi
 
-import (
-	"fmt"
-)
-
 //Model specific registers
 const (
 	msrSMBase             int64 = 0x9e //nolint
@@ -23,13 +19,10 @@ type IA32Debug struct {
 }
 
 //HasSMRR returns true if the CPU supports SMRR
-func (h HwAPI) HasSMRR() (bool, error) {
-	mtrrcap, err := h.ReadMSR(msrMTRRCap, 0)
-	if err != nil {
-		return false, fmt.Errorf("cannot access MSR IA32_MTRRCAP: %s", err)
-	}
+func HasSMRR(h LowLevelHardwareInterfaces) (bool, error) {
+	mtrrcap := h.ReadMSR(msrMTRRCap)
 
-	return (mtrrcap>>11)&1 != 0, nil
+	return (mtrrcap[0]>>11)&1 != 0, nil
 }
 
 // SMRR for the SMM code.
@@ -40,78 +33,57 @@ type SMRR struct {
 }
 
 // GetSMRRInfo returns SMRR config of the platform
-func (h HwAPI) GetSMRRInfo() (SMRR, error) {
+func GetSMRRInfo(h LowLevelHardwareInterfaces) (SMRR, error) {
 	var ret SMRR
 
-	smrrPhysbase, err := h.ReadMSR(msrSMRRPhysBase, 0)
-	if err != nil {
-		return ret, fmt.Errorf("cannot access MSR IA32_SMRR_PHYSBASE: %s", err)
-	}
+	smrrPhysbase := h.ReadMSR(msrSMRRPhysBase)
 
-	smrrPhysmask, err := h.ReadMSR(msrSMRRPhysMask, 0)
-	if err != nil {
-		return ret, fmt.Errorf("cannot access MSR IA32_SMRR_PHYSMASK: %s", err)
-	}
+	smrrPhysmask := h.ReadMSR(msrSMRRPhysMask)
 
-	ret.Active = (smrrPhysmask>>11)&1 != 0
-	ret.PhysBase = (smrrPhysbase >> 12) & 0xfffff
-	ret.PhysMask = (smrrPhysmask >> 12) & 0xfffff
+	ret.Active = (smrrPhysmask[0]>>11)&1 != 0
+	ret.PhysBase = (smrrPhysbase[0] >> 12) & 0xfffff
+	ret.PhysMask = (smrrPhysmask[0] >> 12) & 0xfffff
 
 	return ret, nil
 }
 
 //IA32FeatureControlIsLocked returns true if the IA32_FEATURE_CONTROL msr is locked
-func (h HwAPI) IA32FeatureControlIsLocked() (bool, error) {
-	featCtrl, err := h.ReadMSR(msrFeatureControl, 0)
-	if err != nil {
-		return false, fmt.Errorf("cannot access MSR IA32_FEATURE_CONTROL: %s", err)
-	}
+func IA32FeatureControlIsLocked(h HwAPI) (bool, error) {
+	featCtrl := h.ReadMSR(msrFeatureControl)
 
-	return featCtrl&1 != 0, nil
+	return featCtrl[0]&1 != 0, nil
 }
 
 //IA32PlatformID returns the IA32_PLATFORM_ID msr
-func (h HwAPI) IA32PlatformID() (uint64, error) {
-	pltID, err := h.ReadMSR(msrPlatformID, 0)
-	if err != nil {
-		return 0, fmt.Errorf("cannot access MSR IA32_PLATFORM_ID: %s", err)
-	}
+func IA32PlatformID(h HwAPI) (uint64, error) {
+	pltID := h.ReadMSR(msrPlatformID)
 
-	return pltID, nil
+	return pltID[0], nil
 }
 
 //AllowsVMXInSMX returns true if VMX is allowed in SMX
-func (h HwAPI) AllowsVMXInSMX() (bool, error) {
-	featCtrl, err := h.ReadMSR(msrFeatureControl, 0)
-	if err != nil {
-		return false, fmt.Errorf("cannot access MSR IA32_FEATURE_CONTROL: %s", err)
-	}
+func AllowsVMXInSMX(h HwAPI) (bool, error) {
+	featCtrl := h.ReadMSR(msrFeatureControl)
 
 	var mask uint64 = (1 << 1) & (1 << 5) & (1 << 6)
-	return (mask & featCtrl) == mask, nil
+	return (mask & featCtrl[0]) == mask, nil
 }
 
 //TXTLeavesAreEnabled returns true if all TXT leaves are enabled
-func (h HwAPI) TXTLeavesAreEnabled() (bool, error) {
-	featCtrl, err := h.ReadMSR(msrFeatureControl, 0)
-	if err != nil {
-		return false, fmt.Errorf("cannot access MSR IA32_FEATURE_CONTROL: %s", err)
-	}
+func TXTLeavesAreEnabled(h HwAPI) (bool, error) {
+	featCtrl := h.ReadMSR(msrFeatureControl)
 
-	txtBits := (featCtrl >> 8) & 0x1ff
+	txtBits := (featCtrl[0] >> 8) & 0x1ff
 	return (txtBits&0xff == 0xff) || (txtBits&0x100 == 0x100), nil
 }
 
 //IA32DebugInterfaceEnabledOrLocked returns the enabled, locked and pchStrap state of IA32_DEBUG_INTERFACE msr
-func (h HwAPI) IA32DebugInterfaceEnabledOrLocked() (*IA32Debug, error) {
+func IA32DebugInterfaceEnabledOrLocked(h HwAPI) (*IA32Debug, error) {
 	var debugMSR IA32Debug
-	debugInterfaceCtrl, err := h.ReadMSR(msrIA32DebugInterface, 0)
-	if err != nil {
-		return nil, fmt.Errorf("cannot access MSR IA32_DEBUG_INTERFACE: %s", err)
-	}
+	debugInterfaceCtrl := h.ReadMSR(msrIA32DebugInterface)
 
-	debugMSR.Enabled = (debugInterfaceCtrl>>0)&1 != 0
-	debugMSR.Locked = (debugInterfaceCtrl>>30)&1 != 0
-	debugMSR.PCHStrap = (debugInterfaceCtrl>>31)&1 != 0
+	debugMSR.Enabled = (debugInterfaceCtrl[0]>>0)&1 != 0
+	debugMSR.Locked = (debugInterfaceCtrl[0]>>30)&1 != 0
+	debugMSR.PCHStrap = (debugInterfaceCtrl[0]>>31)&1 != 0
 	return &debugMSR, nil
 }

--- a/pkg/hwapi/smbios.go
+++ b/pkg/hwapi/smbios.go
@@ -145,7 +145,7 @@ func (h HwAPI) IterateOverSMBIOSTables(n uint8, callback func(s *smbios.Structur
 }
 
 // IterateOverSMBIOSTablesType0 returns all SMBIOS tables of Type0 decoded
-func (h HwAPI) IterateOverSMBIOSTablesType0(callback func(t0 *SMBIOSType0) bool) (ret bool, err error) {
+func IterateOverSMBIOSTablesType0(h LowLevelHardwareInterfaces, callback func(t0 *SMBIOSType0) bool) (ret bool, err error) {
 	var err2 error
 	ret, err = h.IterateOverSMBIOSTables(uint8(0), func(s *smbios.Structure) bool {
 		var decoded SMBIOSType0
@@ -205,7 +205,7 @@ func (h HwAPI) IterateOverSMBIOSTablesType0(callback func(t0 *SMBIOSType0) bool)
 }
 
 // IterateOverSMBIOSTablesType17 returns all SMBIOS tables of Type17 decoded
-func (h HwAPI) IterateOverSMBIOSTablesType17(callback func(t17 *SMBIOSType17) bool) (ret bool, err error) {
+func IterateOverSMBIOSTablesType17(h LowLevelHardwareInterfaces, callback func(t17 *SMBIOSType17) bool) (ret bool, err error) {
 	var err2 error
 	ret, err = h.IterateOverSMBIOSTables(uint8(17), func(s *smbios.Structure) bool {
 		var decoded SMBIOSType17

--- a/pkg/hwapi/smbios_test.go
+++ b/pkg/hwapi/smbios_test.go
@@ -11,7 +11,7 @@ func TestSMBIOSQemu(t *testing.T) {
 		t.Skip("Not running on QEMU")
 	}
 	count := 0
-	_, err := h.IterateOverSMBIOSTablesType0(func(s *SMBIOSType0) bool {
+	_, err := IterateOverSMBIOSTablesType0(h, func(s *SMBIOSType0) bool {
 		count++
 		if s.Type != 0 {
 			t.Errorf("Got unexpected type %d", s.Type)
@@ -44,7 +44,7 @@ func TestSMBIOSType17(t *testing.T) {
 		t.Skip("Not running on QEMU")
 	}
 	count := 0
-	_, err := h.IterateOverSMBIOSTablesType17(func(s *SMBIOSType17) bool {
+	_, err := IterateOverSMBIOSTablesType17(h, func(s *SMBIOSType17) bool {
 		count++
 		if s.Type != 17 {
 			t.Errorf("Got unexpected type %d", s.Type)


### PR DESCRIPTION
*	PCIReadConfigSpace takes amount of bytes to read
	and returns data as byte-slice

*	Move HasSMRR, GetSMRRInfo, IA32FeatureControlIsLocked,
	AllowVMXInSMX, TXTLeavesAreEnabled, IA32DebugInterfaceEnabledOrLocked
	out of API. Now as convenience function (needs further cleanup)

*	Change ReadMSR again: Now returns data of all cores in a slice

*	Adapt changes to all related code

Signed-off-by: Christopher Meis <christopher.meis@9elements.com>