### PR TITLE
Add support for GOARCH=386

### DIFF
--- a/pkg/hwapi/cpuid_amd64.go
+++ b/pkg/hwapi/cpuid_amd64.go
@@ -1,3 +1,4 @@
+//go:build amd64
 // +build amd64
 
 // Package hwapi provides access to low level hardware

--- a/pkg/hwapi/cpuid_other.go
+++ b/pkg/hwapi/cpuid_other.go
@@ -1,3 +1,4 @@
+//go:build !amd64
 // +build !amd64
 
 // Package hwapi provides access to low level hardware

--- a/pkg/hwapi/phys_be.go
+++ b/pkg/hwapi/phys_be.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build arm || arm64 || ppc64le
 // +build arm arm64 ppc64le
 
 package hwapi

--- a/pkg/hwapi/phys_le.go
+++ b/pkg/hwapi/phys_le.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build x86 amd64
+//go:build 386 || amd64
+// +build 386 amd64
 
 package hwapi
 


### PR DESCRIPTION
`x86` is an invalid `GOARCH`. Changing to `386`.

Also `gofmt` added `//go:build` comments.