### PR TITLE
Adapt tests and msr_intel to changes in ReadMSR

### DIFF
--- a/pkg/hwapi/msr_intel.go
+++ b/pkg/hwapi/msr_intel.go
@@ -1,6 +1,6 @@
 package hwapi
 
-//Model specific registers
+// Model specific registers
 const (
 	msrSMBase             int64 = 0x9e //nolint
 	msrMTRRCap            int64 = 0xfe
@@ -18,11 +18,11 @@ type IA32Debug struct {
 	PCHStrap bool
 }
 
-//HasSMRR returns true if the CPU supports SMRR
+// HasSMRR returns true if the CPU supports SMRR
 func HasSMRR(h LowLevelHardwareInterfaces) (bool, error) {
 	mtrrcap := h.ReadMSR(msrMTRRCap)
 
-	return (mtrrcap[0]>>11)&1 != 0, nil
+	return (mtrrcap>>11)&1 != 0, nil
 }
 
 // SMRR for the SMM code.
@@ -40,50 +40,50 @@ func GetSMRRInfo(h LowLevelHardwareInterfaces) (SMRR, error) {
 
 	smrrPhysmask := h.ReadMSR(msrSMRRPhysMask)
 
-	ret.Active = (smrrPhysmask[0]>>11)&1 != 0
-	ret.PhysBase = (smrrPhysbase[0] >> 12) & 0xfffff
-	ret.PhysMask = (smrrPhysmask[0] >> 12) & 0xfffff
+	ret.Active = (smrrPhysmask>>11)&1 != 0
+	ret.PhysBase = (smrrPhysbase >> 12) & 0xfffff
+	ret.PhysMask = (smrrPhysmask >> 12) & 0xfffff
 
 	return ret, nil
 }
 
-//IA32FeatureControlIsLocked returns true if the IA32_FEATURE_CONTROL msr is locked
+// IA32FeatureControlIsLocked returns true if the IA32_FEATURE_CONTROL msr is locked
 func IA32FeatureControlIsLocked(h LowLevelHardwareInterfaces) (bool, error) {
 	featCtrl := h.ReadMSR(msrFeatureControl)
 
-	return featCtrl[0]&1 != 0, nil
+	return featCtrl&1 != 0, nil
 }
 
-//IA32PlatformID returns the IA32_PLATFORM_ID msr
+// IA32PlatformID returns the IA32_PLATFORM_ID msr
 func IA32PlatformID(h LowLevelHardwareInterfaces) (uint64, error) {
 	pltID := h.ReadMSR(msrPlatformID)
 
-	return pltID[0], nil
+	return pltID, nil
 }
 
-//AllowsVMXInSMX returns true if VMX is allowed in SMX
+// AllowsVMXInSMX returns true if VMX is allowed in SMX
 func AllowsVMXInSMX(h LowLevelHardwareInterfaces) (bool, error) {
 	featCtrl := h.ReadMSR(msrFeatureControl)
 
 	var mask uint64 = (1 << 1) & (1 << 5) & (1 << 6)
-	return (mask & featCtrl[0]) == mask, nil
+	return (mask & featCtrl) == mask, nil
 }
 
-//TXTLeavesAreEnabled returns true if all TXT leaves are enabled
+// TXTLeavesAreEnabled returns true if all TXT leaves are enabled
 func TXTLeavesAreEnabled(h LowLevelHardwareInterfaces) (bool, error) {
 	featCtrl := h.ReadMSR(msrFeatureControl)
 
-	txtBits := (featCtrl[0] >> 8) & 0x1ff
+	txtBits := (featCtrl >> 8) & 0x1ff
 	return (txtBits&0xff == 0xff) || (txtBits&0x100 == 0x100), nil
 }
 
-//IA32DebugInterfaceEnabledOrLocked returns the enabled, locked and pchStrap state of IA32_DEBUG_INTERFACE msr
+// IA32DebugInterfaceEnabledOrLocked returns the enabled, locked and pchStrap state of IA32_DEBUG_INTERFACE msr
 func IA32DebugInterfaceEnabledOrLocked(h LowLevelHardwareInterfaces) (*IA32Debug, error) {
 	var debugMSR IA32Debug
 	debugInterfaceCtrl := h.ReadMSR(msrIA32DebugInterface)
 
-	debugMSR.Enabled = (debugInterfaceCtrl[0]>>0)&1 != 0
-	debugMSR.Locked = (debugInterfaceCtrl[0]>>30)&1 != 0
-	debugMSR.PCHStrap = (debugInterfaceCtrl[0]>>31)&1 != 0
+	debugMSR.Enabled = (debugInterfaceCtrl>>0)&1 != 0
+	debugMSR.Locked = (debugInterfaceCtrl>>30)&1 != 0
+	debugMSR.PCHStrap = (debugInterfaceCtrl>>31)&1 != 0
 	return &debugMSR, nil
 }


### PR DESCRIPTION
Changes in #16 break the tests for msr_intel.go. This PR adapts both the logic in msr_intel, and the tests. 